### PR TITLE
Provide stable work of checkboxes

### DIFF
--- a/anki-browser-search-modifiers.py
+++ b/anki-browser-search-modifiers.py
@@ -2,22 +2,16 @@
 
 """
 Anki Add-on: Browser search modifiers
-
 Adds two checkboxes to the browser search form that, when toggled, modify
 searches in the following way:
-
 Deck (Hotkey: Alt+D): Limit results to current deck
 Card (Hotkey: Alt+C): Limit results to first card of each note
-
 Based on the following add-ons:
-
 - "Limit searches to current deck" by Damien Elmes
    (https://github.com/dae/ankiplugins/blob/master/searchdeck.py)
 - "Ignore accents in browser search" by Houssam Salem
    (https://github.com/hssm/anki-addons)
-
 Original idea by Keven on Anki tenderapp
-
 Copyright: (c) Glutanimate 2016
 License: GNU GPL, version 3 or later; http://www.gnu.org/copyleft/gpl.html
 """
@@ -33,39 +27,65 @@ from anki.hooks import wrap, addHook
 default_checkbox_conf = {'deck_check_checked': False,
                          'card_check_checked': False}
 
+deckChanged = False
+cardChanged = False
+
 def onSearch(self, reset=True):
     """Modify search entry."""
+
+    global deckChanged, cardChanged
     txt = unicode(self.form.searchEdit.lineEdit().text()).strip()
+
+    if self.form.cardToggleButton.isChecked():
+        if "card:" in txt:
+            pass
+        elif _("<type here to search; hit enter to show current deck>") in txt:
+            pass
+        elif "is:current" in txt:
+            pass
+        else:
+            txt = "card:1 " + txt
+    elif cardChanged:
+        txt = txt.replace("card:1","")
+    cardChanged = False
+
+    txt = txt.strip()
+
     if self.form.deckToggleButton.isChecked():
         if "deck:" in txt:
             pass
         elif _("<type here to search; hit enter to show current deck>") in txt:
-            txt = "deck:current"
+            pass
         elif "is:current" in txt:
+            pass
+        elif txt == "" or txt == 'deck:current' or txt == 'card:1' or txt == 'card:1 deck:current':
             pass
         else:
             txt = "deck:current " + txt
-    else:
-        txt = txt.replace("deck:current","")
-    if self.form.cardToggleButton.isChecked():
-        if "card:1" in txt:
-            txt.replace("card:1","")
-        elif "card:" in txt:
-            pass
-        elif _("<type here to search; hit enter to show current deck>") in txt:
-            pass
-        else:
-            txt = "card:1 " + txt
-    else:
-        txt = txt.replace("card:1","")
+    elif deckChanged:
+        if txt != 'deck:current' and txt != 'card:1 deck:current':
+            txt = txt.replace("deck:current","")
+    deckChanged = False
+
     self.form.searchEdit.lineEdit().setText(txt)
-   
+
+def onDeckChecked(state):
+    '''Save the checked state in Anki's configuration.'''
+    global deckChanged
+    mw.col.conf['browser_checkbox_conf']['deck_check_checked'] = state
+    deckChanged = True
+
+def onCardChecked(state):
+    global cardChanged
+    mw.col.conf['browser_checkbox_conf']['card_check_checked'] = state
+    cardChanged = True
+
 def mySetupUi(self, mw):
     """Add new items to the browser UI to allow toggling the add-on."""
 
     # Our UI stuff
-    self.deckToggleButton = QCheckBox("Deck", self.widget)
-    self.cardToggleButton = QCheckBox("Card", self.widget)
+    self.deckToggleButton = QCheckBox(_("Deck"), self.widget)
+    self.cardToggleButton = QCheckBox(_("Card"), self.widget)
     self.deckToggleButton.setToolTip("Limit results to current deck")
     self.cardToggleButton.setToolTip("Limit results to first card of each note")
 
@@ -96,31 +116,21 @@ def mySetupUi(self, mw):
     
     for i, item in enumerate(items):
         self.gridLayout.addWidget(item, 0, i, 1, 1)
-        
-    
-def onDeckChecked(state):
-    '''Save the checked state in Anki's configuration.'''
-    mw.col.conf['browser_checkbox_conf']['deck_check_checked'] = state
-def onCardChecked(state):
-    mw.col.conf['browser_checkbox_conf']['card_check_checked'] = state
-    
-
 
 def onSetupMenus(self):
     '''Toggle state via key bindings.'''
-    # setup hotkeys
     self.a = QShortcut(QKeySequence("Alt+C"), self)
     self.connect(self.a, SIGNAL("activated()"), lambda c=self: c.form.cardToggleButton.toggle())
     self.a = QShortcut(QKeySequence("Alt+D"), self)
     self.connect(self.a, SIGNAL("activated()"), lambda c=self: c.form.deckToggleButton.toggle())
+
     # execute search when toggling checkmarks
     self.connect(self.form.deckToggleButton,
                  SIGNAL("stateChanged(int)"),
-                 self.onSearch)
+                 self.onReset)
     self.connect(self.form.cardToggleButton,
                  SIGNAL("stateChanged(int)"),
-                 self.onSearch)
-
+                 self.onReset)
 
 Ui_Dialog.setupUi = wrap(Ui_Dialog.setupUi, mySetupUi)
 Browser.onSearch = wrap(Browser.onSearch, onSearch, "before")


### PR DESCRIPTION
.onSearch -> .onReset
remove keywords not each time, only after removing the tick from the checkbox
Whole Collection and Current Deck in left Browser Tree have precedence over Deck checkbox