### PR TITLE
Fix progress bar text not shown in revision screen

### DIFF
--- a/src/reviewer_progress_bar.py
+++ b/src/reviewer_progress_bar.py
@@ -251,6 +251,7 @@ def _renderBar(state, oldState):
         if not progressBar: progressBar, mx = pb()
         else: rrenderPB()
         _getLimitedBarLength()
+        _updatePB()
         progressBar.show()
         nmc()
     elif state == "deckBrowser":

--- a/src/reviewer_progress_bar.py
+++ b/src/reviewer_progress_bar.py
@@ -251,7 +251,8 @@ def _renderBar(state, oldState):
         if not progressBar: progressBar, mx = pb()
         else: rrenderPB()
         _getLimitedBarLength()
-        _updatePB()
+        if showNumber:
+            _updatePB()
         progressBar.show()
         nmc()
     elif state == "deckBrowser":


### PR DESCRIPTION
### Problem
Even if you change your settings to _showPercent=True_ or _showNumber=True_ these numbers won't be shown in the overview screen (will only appear when you actually start reviewing). 

I feel that the numbers appearing in the overview screen is the expected behavior.