### PR TITLE
Stack with any existing dockWidgets

### DIFF
--- a/src/reviewer_progress_bar.py
+++ b/src/reviewer_progress_bar.py
@@ -134,7 +134,25 @@ def _dock(pb):
     dock.setObjectName("pbDock")
     dock.setWidget(pb)
     dock.setTitleBarWidget( tWidget )
+    
+    ## Note: if there is another widget already in this dock position, we have to add ourself to the list
+
+    # first check existing widgets
+    existing_widgets = [widget for widget in mw.findChildren(QDockWidget) if mw.dockWidgetArea(widget) == dockArea]
+
+    # then add ourselves
     mw.addDockWidget(dockArea, dock)
+
+    # stack with any existing widgets
+    if len(existing_widgets) > 0:
+        mw.setDockNestingEnabled(True)
+
+        if dockArea == Qt.TopDockWidgetArea or dockArea == Qt.BottomDockWidgetArea:
+            stack_method = Qt.Vertical
+        if dockArea == Qt.LeftDockWidgetArea or dockArea == Qt.RightDockWidgetArea:
+            stack_method = Qt.Horizontal
+        mw.splitDockWidget(existing_widgets[0], dock, stack_method)
+
     if qbr > 0 or pbdStyle != None:
         # Matches background for round corners.
         # Also handles background for themes' percentage text.


### PR DESCRIPTION
I noticed that this plugin doesn't play well with other plugins that add to the dockWidget (usually causing one of the plugins not to render)
In an attempt to fix this, this plugin now checks if anybody else is in the desired dockArea and if somebody is there it will split the UI to share the space. 
## Problems
1) If there are many widgets in a dockArea, we add ourselves at a mostly random position which might be between 2 other dockWidgets. Not the perfect behavior but nothing better is possible without having coordination between different plugins
2) If another plugin runs after ours and doesn't have similar logic, they may override our UI (this was always a problem though). I think we could fix this by checking if our widget is properly docked every time the state changes but I didn't really want to spend the time doing the investigation to make this work.