### PR TITLE
Fix: % in css needs to be escaped by using %%

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ meta.json
 .directory
 docs/sort-sections.sh
 build
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@ meta.json
 .directory
 docs/sort-sections.sh
 build
-.vscode/

--- a/src/editor_custom_stylesheet/editor_custom_stylesheet.py
+++ b/src/editor_custom_stylesheet/editor_custom_stylesheet.py
@@ -65,7 +65,7 @@ def profileLoaded():
         css = css_file.read()
     if not css:
         return False
-    editor_style = "<style>\n{}\n</style>".format(css)
+    editor_style = "<style>\n{}\n</style>".format(css.replace("%","%%"))
     old_html = editor._html
     editor._html = editor._html + editor_style
     new_html = editor._html


### PR DESCRIPTION
Before appending css to original html, % has to be escaped by %%, or python will treat % as a placeholder sign.