### PR TITLE
fix: when new tag is input maybe completion will be whitespace

### DIFF
--- a/src/tagedit_enhancements/tagedit_enhancements.py
+++ b/src/tagedit_enhancements/tagedit_enhancements.py
@@ -84,7 +84,7 @@ def applyCompletion(self):
         return False
     self.completer.setCompletionPrefix(pfx)
     completion = self.completer.currentCompletion()
-    if not completion:
+    if (not completion or not completion.strip()):
         return False
     tags[tidx] = completion + " "
     self.setText(" ".join(tags))


### PR DESCRIPTION
Hi, I just found when I type a new tag, then I press the "Enter" key, the tag will be replaced " "(whitespace), so I think when we checking the completion, we also should trim it.

I give a pull request, it's ok for me now.

can you review it?