### PR TITLE
Import _ from lang in browser replace tag

### DIFF
--- a/src/browser_replace_tag/browser_replace_tag.py
+++ b/src/browser_replace_tag/browser_replace_tag.py
@@ -14,6 +14,7 @@ from aqt.qt import *
 from aqt.utils import getText, tooltip
 from aqt.tagedit import TagEdit
 from anki.hooks import addHook
+from anki.lang import _
 
 
 def myGetTag(parent, deck, question, tags="user", taglist=None, **kwargs):


### PR DESCRIPTION
Just to get rid of that `accessing _ without importing from anki.lang will break in the future` warning.

Tested on Debian bullseye with Anki Version 2.1.22 (2f028678), Python 3.7.6 Qt 5.12.5 PyQt 5.14.1