### PR TITLE
Editor field history: Use double quotes in query

### DIFF
--- a/src/editor_field_history/editor_field_history.py
+++ b/src/editor_field_history/editor_field_history.py
@@ -168,7 +168,7 @@ def restoreEditorFields(self, mode):
 
     # Perform search
     if deck:
-        query = "deck:'%s'" % (deck)
+        query = 'deck:"%s"' % (deck)
         results = self.note.col.findNotes(query)
     if not results:
         tooltip("Could not find any past notes in current deck.<br>"


### PR DESCRIPTION
[Single-quote searches are no longer supported.](https://betas.ankiweb.net/#/?id=changes-in-2124beta1)