### PR TITLE
Added maxNotes parameter to field history.

### DIFF
--- a/src/editor_field_history/config.md
+++ b/src/editor_field_history/config.md
@@ -5,4 +5,4 @@
 - `partialRestoreShortcut` (string): Hotkey that restores fields listed in `partialRestoreFields`. Default: `"Alt+Shift+Z"`.
 - `fullRestoreShortcut` (string): Hotkey that restores all fields at once, tags included: `"Ctrl+Alt+Shift+Z"`.
 - `partialRestoreFields` (list): List of fields to restore when using `partialRestoreShortcut` (e.g. `["Front", "Sources"]`. Default: `[]`.
-
+- `maxNotes` (int): Maximum number of notes to query when checking field history. Default: `100`

--- a/src/editor_field_history/config.schema.json
+++ b/src/editor_field_history/config.schema.json
@@ -36,6 +36,12 @@
         "title": "field",
         "type": "string"
       }
-    }
+    },
+    "maxNotes": {
+      "type": "number",
+      "title": "Max notes",
+      "description": "Maximum number of notes to query when checking field history.",
+      "default": 100
+     }
   }
 }

--- a/src/editor_field_history/editor_field_history.py
+++ b/src/editor_field_history/editor_field_history.py
@@ -46,6 +46,7 @@ if ANKI21:
     partial_restore_shortcut = config["partialRestoreShortcut"]
     full_restore_shortcut = config["fullRestoreShortcut"]
     partial_restore_fields = config["partialRestoreFields"]
+    max_notes = config["maxNotes"]
 
 # Ctrl+Alt+H is a global hotkey on macOS
 # Hacky solution for anki21. A platform-specific config.json would be
@@ -86,7 +87,7 @@ def historyRestore(self, mode, results, model, fld):
     field = model['flds'][fld]['name']
     last_val = {}
     keys = []
-    for nid in results[:100]:
+    for nid in results[:max_notes]:
         oldNote = self.note.col.getNote(nid)
         if field in oldNote:
             html = oldNote[field]


### PR DESCRIPTION
Added the maxNotes parameter to config.

I have an extra field in my custom note type that has a 'context' field (e.g. 'Python' for Python cards), so if I do not add a card with this context in the last 100 cards (about a week's worth of cards), the older values for this field do not show up.

With ~6000 cards in my deck, this does not noticeably affect speed when I turn `maxNotes` up to the size of the deck. 

First time committing to this repo so feedback welcome