### PR TITLE
Adapt Progress Bar for Anki 2.1.28+ using deck_due_tree

### DIFF
--- a/src/reviewer_progress_bar/reviewer_progress_bar.py
+++ b/src/reviewer_progress_bar/reviewer_progress_bar.py
@@ -6,13 +6,14 @@ Shows progress in the Reviewer in terms of passed cards per session.
 
 Copyright:  (c) Unknown author (nest0r/Ja-Dark?) 2017
             (c) SebastienGllmt 2017 <https://github.com/SebastienGllmt/>
-            (c) liuzikai 2018 <https://github.com/liuzikai>
+            (c) liuzikai 2018-2020 <https://github.com/liuzikai>
             (c) Glutanimate 2017-2018 <https://glutanimate.com/>
 License: GNU AGPLv3 or later <https://www.gnu.org/licenses/agpl.html>
 """
 
 # Do not modify the following lines
 from __future__ import unicode_literals
+from typing import Optional
 
 from anki.hooks import addHook, wrap
 from anki import version as anki_version
@@ -22,7 +23,7 @@ from aqt.utils import showInfo
 from aqt.qt import *
 from aqt import mw
 
-__version__ = '2.0.0'
+__version__ = '2.0.1'
 
 ############## USER CONFIGURATION START ##############
 
@@ -38,15 +39,15 @@ includeNewAfterRevs = True
 
 # Calculation weights
 #
-#   Setting proper weights will make the progress bar goes smoothly and decrease the chance of going backwards.
+#   Setting proper weights will make the progress bar goes smoothly and reasonably.
 #
 #   For example, if all weight are 1, and you set 2 steps for a new card in your desk config, you will convey
 #   one 'new' into two 'learning' card if you press 'again' at the first time, which will increase remaining
 #   count and cause the bar to move backward.
 #
-#   In this case, it's not a bad idea to set newWeight to 2, and remaining count will be calculated as
-#   new * 2 + learn + review.Now pressing 'again' will just make it stop going forward, but not backward. If
-#   you press 'esay' at first, the progress will go twice as fast, which is still reasonable.
+#   In this case, it's probably a good idea to set newWeight to 2, and remaining count will be calculated as
+#   new * 2 + learn + review. Now pressing 'again' will just make it stop going forward, but not backward. If
+#   you press 'easy' at first, the progress will go twice as fast, which is still reasonable.
 #
 #   However, if you press 'good' followed by 'again', there will be another two learning card again, and the
 #   progress still needs to go backward. It may not be a big deal, but if you want the progress never goes
@@ -58,7 +59,7 @@ includeNewAfterRevs = True
 #   three new cards in a note, there will be 3 new cards at the beginning of your review, but another two will
 #   disappear instantly after you learn one of them. However, all three cards will be regarded as 'completed,'
 #   so your progress may go three times as fast.
-#
+
 newWeight = 2
 revWeight = 1
 lrnWeight = 1
@@ -74,14 +75,14 @@ showPercent = False  # Show the progress text percentage or not.
 showNumber = False  # Show the progress text as a fraction
 
 qtxt = "aliceblue"  # Percentage color, if text visible.
-qbg = "#ececec"  # Background color of progress bar.
+qbg = "rgba(0, 0, 0, 0)"  # Background color of progress bar.
 qfg = "#3399cc"  # Foreground color of progress bar.
 qbr = 0  # Border radius (> 0 for rounded corners).
 
 # optionally restricts progress bar width
 maxWidth = "5px"  # (e.g. "5px". default: "")
 
-floatingBarWhenEditing = True # Make the progress bar 'floating' when waiting to resume.
+scrollingBarWhenEditing = True  # Make the progress bar 'scrolling' when waiting to resume.
 
 orientationHV = Qt.Horizontal  # Show bar horizontally (side to side). Use with top/bottom dockArea.
 # orientationHV = Qt.Vertical # Show bar vertically (up and down). Use with right/left dockArea.
@@ -103,22 +104,22 @@ pbStyle = ""  # Stylesheet used only if blank. Else uses QPalette + theme style.
 
 ##############  USER CONFIGURATION END  ##############
 
-## Set up variables
+# Set up variables
 
 remainCount = {}  # {did: remaining count (weighted) of the deck}, calculated with data from Anki col and sched
 doneCount = {}  # {did: done count (weighted) of the deck}, calculated as total - remain when showing next question
 totalCount = {}  # {did: max total count (weighted) that was seen}, calculated as remain + done after state change
 # NOTE: did stands for 'deck id'
-# See comments on updateCounts() for further usage.
+# See comments on updateCountsForAllDecks() for further usage.
 
 
-currDID = None  # current deck id (None means at the deck browser)
+currDID: Optional[int] = None  # current deck id (None means at the deck browser)
 
 nmStyleApplied = 0
 nmUnavailable = 0
-progressBar = None
+progressBar: Optional[QProgressBar] = None
 
-pbdStyle = QStyleFactory.create("%s" % (pbStyle))  # Don't touch.
+pbdStyle = QStyleFactory.create("%s" % pbStyle)  # Don't touch.
 
 # Defining palette in case needed for custom colors with themes.
 palette = QPalette()
@@ -153,17 +154,17 @@ except ImportError:
     nmUnavailable = 1
 
 
-def initPB():
+def initPB() -> None:
     """Initialize and set parameters for progress bar, adding it to the dock."""
     global progressBar
     progressBar = QProgressBar()
     progressBar.setTextVisible(showPercent or showNumber)
     progressBar.setInvertedAppearance(invertTF)
     progressBar.setOrientation(orientationHV)
-    if pbdStyle == None:
+    if pbdStyle is None:
         progressBar.setStyleSheet(
             '''
-                    QProgressBar
+                QProgressBar
                 {
                     text-align:center;
                     color:%s;
@@ -171,7 +172,7 @@ def initPB():
                     border-radius: %dpx;
                     %s
                 }
-                    QProgressBar::chunk
+                QProgressBar::chunk
                 {
                     background-color: %s;
                     margin: 0px;
@@ -184,7 +185,7 @@ def initPB():
     _dock(progressBar)
 
 
-def _dock(pb):
+def _dock(pb: QProgressBar) -> QDockWidget:
     """Dock for the progress bar. Giving it a blank title bar,
         making sure to set focus back to the reviewer."""
     dock = QDockWidget()
@@ -193,7 +194,7 @@ def _dock(pb):
     dock.setWidget(pb)
     dock.setTitleBarWidget(tWidget)
 
-    ## Note: if there is another widget already in this dock position, we have to add ourself to the list
+    # Note: if there is another widget already in this dock position, we have to add ourself to the list
 
     # first check existing widgets
     existing_widgets = [widget for widget in mw.findChildren(QDockWidget) if mw.dockWidgetArea(widget) == dockArea]
@@ -211,7 +212,7 @@ def _dock(pb):
             stack_method = Qt.Horizontal
         mw.splitDockWidget(existing_widgets[0], dock, stack_method)
 
-    if qbr > 0 or pbdStyle != None:
+    if qbr > 0 or pbdStyle is not None:
         # Matches background for round corners.
         # Also handles background for themes' percentage text.
         mw.setPalette(palette)
@@ -219,26 +220,20 @@ def _dock(pb):
     return dock
 
 
-def updatePB():
+def updatePB() -> None:
     """Update progress bar range and value with currDID, totalCount[] and doneCount[]"""
     if currDID:
         # In a specific deck
-        deckName = mw.col.decks.name(currDID)
-        pbMax = pbValue = 0
-        # Sum up all children decks
-        for deckProp in mw.col.sched.deckDueList():
-            name = deckProp[0]
-            did = deckProp[1]
-            if name.startswith(deckName):
-                pbMax += totalCount[did]
-                pbValue += doneCount[did]
+        pbMax = totalCount[currDID]
+        pbValue = doneCount[currDID]
     else:
         # At desk browser
         pbMax = sum(totalCount.values())
         pbValue = sum(doneCount.values())
+
     # showInfo("pbMax = %d, pbValue = %d" % (pbMax, pbValue))
 
-    if pbMax == 0:
+    if pbMax == 0:  # 100%
         progressBar.setRange(0, 1)
         progressBar.setValue(1)
     else:
@@ -254,7 +249,7 @@ def updatePB():
     nmApplyStyle()
 
 
-def setFloatingPB():
+def setScrollingPB() -> None:
     """Make progress bar in waiting style if the state is resetRequired (happened after editing cards.)"""
     progressBar.setRange(0, 0)
     if showNumber:
@@ -262,7 +257,7 @@ def setFloatingPB():
     nmApplyStyle()
 
 
-def nmApplyStyle():
+def nmApplyStyle() -> None:
     """Checks whether Night_Mode is disabled:
         if so, we remove the separator here."""
     global nmStyleApplied
@@ -279,112 +274,105 @@ def nmApplyStyle():
     ''')
 
 
-def calcCount(revRaw, lrnRaw, newRaw):
-    """Calculate count with weights with raw values from the sched."""
-    rev = lrn = new = 0
+def calcProgress(rev: int, lrn: int, new: int) -> int:
+    """Calculate progress using weights and card counts from the sched."""
+    ret = 0
     if includeRev:
-        rev = revRaw * revWeight
+        ret += rev * revWeight
     if includeLrn:
-        lrn = lrnRaw * lrnWeight
+        ret += lrn * lrnWeight
     if includeNew or (includeNewAfterRevs and rev == 0):
-        new = newRaw * newWeight
-    return rev + lrn + new
+        ret += new * newWeight
+    return ret
 
 
-def initCounts():
-    """Iterate decks and initialize totalCount[], remainCount[] and doneCount[]."""
-    for deckProp in mw.col.sched.deckDueList():
-        _initCounts(deckProp[1], calcCount(deckProp[2], deckProp[3], deckProp[4]))
+def updateCountsForAllDecks(updateTotal: bool) -> None:
+    """
+    Update counts.
 
+    After adding, editing or deleting cards (afterStateChange hook), updateTotal should be set to True to update
+    totalCount[] based on doneCount[] and remainCount[]. No card should have been answered before this hook is
+    triggered, so the change in remainCount[] should be caused by editing collection and therefore goes into
+    totalCount[].
 
-def _initCounts(did, remain):
-    totalCount[did] = remainCount[did] = remain
-    doneCount[did] = 0
+    When the user answer a card (showQuestion hook), updateTotal should be set to False to update doneCount[] based on
+    totalCount[] and remainCount[]. No change to collection should have been made before this hook is
+    triggered, so the change in remainCount[] should be caused by answering cards and therefore goes into
+    doneCount[].
 
+    In the later case, remainCount[] may still increase based on the weights of New, Lrn and Rev cards (see comments
+    of "Calculation weights" above), in which case totalCount[] may still get updated based on forceForward setting.
 
-# When state change (happens after adding, editing or deleting cards), forceUpdateTotal = True,
-#   totalCount = doneCount + remainCount. User doesn't answer questions during this process, so doneCount should not
-#   change. Changes in remainCount are caused by user's adding, editing or deleting, so totalCount should be
-#   re-evaluated based on doneCount + remainCount.
-# When 'showQuestion' is triggered, forceUpdateTotal = False, doneCount = totalCount - remainCount. The changes in
-#    remainCount are expected to be caused by answering questions, so the changed parts should be regarded as 'done.'
+    :param updateTotal: True for afterStateChange hook, False for showQuestion hook
+    """
 
-
-def updateCounts(forceUpdateTotal):
-    """Update totalCount[], remainCount[] and doneCount[].
-       If forceUpdateTotal, update totalCount based on doneCount and remainCount.
-       If not, update doneCount based on remainCount and totalCount, and increase totalCount only if needed."""
-    # if currDID:
-    #     # When in reviewer, to get correct card count, we have to use the following codes.
-    #     # Excerpted from Anki reviewer
-    #     if mw.reviewer.hadCardQueue:
-    #         counts = list(mw.col.sched.counts())
-    #     else:
-    #         counts = list(mw.col.sched.counts(mw.reviewer.card))
-    #
-    #     _updateCounts(currDID, calcCount(counts[2], counts[1], counts[0]), forceUpdateTotal)
-    # else:
-    availableDID = []  # record exist deck ids, for cleaning up
-    for deckProp in mw.col.sched.deckDueList():
-        did = deckProp[1]
-        availableDID.append(did)
-        remain = calcCount(deckProp[2], deckProp[3], deckProp[4])
-        if did not in totalCount.keys():
-            _initCounts(did, remain)
-            # showInfo("New inited deck %s, remain = %d" % (deckProp[0], remain))
-        else:
-            _updateCounts(did, remain, forceUpdateTotal)
-
-    # delete counts of unavailable decks
-    for did in totalCount.keys():
-        if did not in availableDID:
-            del totalCount[did], remainCount[did], doneCount[did]
-
-
-def _updateCounts(did, remain, forceUpdateTotal):
-    remainCount[did] = remain
-
-    if forceUpdateTotal:
-        totalCount[did] = doneCount[did] + remainCount[did]  # See comments above updateCounts() for explanation.
+    if anki_version.startswith("2.0.") or (anki_version.startswith("2.1.") and int(anki_version.split(".")[-1]) < 28):
+        for deckProp in mw.col.sched.deckDueList():
+            did = deckProp[1]
+            remain = calcProgress(deckProp[2], deckProp[3], deckProp[4])
+            updateCountsForDeck(did, remain, updateTotal)
     else:
-        if remainCount[did] + doneCount[did] > totalCount[did]:
-            if forceForward:
-                return  # Give up changing counts, until the remainCount decrease.
-            else:
+        for node in mw.col.sched.deck_due_tree().children:
+            updateCountsForTree(node, updateTotal)
+
+
+def updateCountsForTree(node, updateTotal: bool) -> None:
+
+    did = node.deck_id
+    remain = calcProgress(node.review_count, node.learn_count, node.new_count)
+
+    updateCountsForDeck(did, remain, updateTotal)
+
+    for child in node.children:
+        updateCountsForTree(child, updateTotal)
+
+
+def updateCountsForDeck(did: int, remain: int, updateTotal: bool):
+    if did not in totalCount.keys():
+        totalCount[did] = remainCount[did] = remain
+        doneCount[did] = 0
+    else:
+        remainCount[did] = remain
+        if updateTotal:
+            totalCount[did] = doneCount[did] + remainCount[did]
+        else:
+            if remainCount[did] + doneCount[did] > totalCount[did]:
                 # This may happen if you press 'again' followed by 'good' for a new card, as stated in comments
-                #    'Calculation weights,' or when you undo a card, making remaining count increases.
+                # "Calculation weights,' or when you undo a card, making remaining count increases.
 
-                # showInfo("Not forced update total from %d to %d" % (totalCount[did], doneCount[did] + remainCount[did]))
-                totalCount[did] = doneCount[did] + remainCount[did]
-        # showInfo("Confirm doneCount changes, did %d" % did)
-        doneCount[did] = totalCount[did] - remainCount[did]  # See comments above updateCounts() for explanation.
+                if forceForward:
+                    pass  # give up changing counts, until the remainCount decrease.
+                else:
+                    totalCount[did] = doneCount[did] + remainCount[did]
+            else:
+                doneCount[did] = totalCount[did] - remainCount[did]
 
 
-def afterStateChangeCallBack(state, oldState):
+def afterStateChangeCallBack(state: str, oldState: str) -> None:
     global currDID
 
     if state == "resetRequired":
-        if floatingBarWhenEditing:
-            setFloatingPB()
+        if scrollingBarWhenEditing:
+            setScrollingPB()
         return
     elif state == "deckBrowser":
         # initPB() has to be here, since objects are not prepared yet when the add-on is loaded.
         if not progressBar:
             initPB()
-            initCounts()
+            updateCountsForAllDecks(True)
         currDID = None
     else:  # "overview" or "review"
         # showInfo("mw.col.decks.current()['id'])= %d" % mw.col.decks.current()['id'])
         currDID = mw.col.decks.current()['id']
 
-    # showInfo("updateCounts(False) 0, currDID = %d" % (currDID if currDID else 0))
-    updateCounts(True)  # See comments above updateCounts() for explanation.
+    # showInfo("updateCountsForAllDecks(True), currDID = %d" % (currDID if currDID else 0))
+    updateCountsForAllDecks(True)  # see comments at updateCountsForAllDecks()
     updatePB()
 
 
-def showQuestionCallBack():
-    # showInfo("updateCounts(False) 1, currDID = %d" % (currDID if currDID else 0))
-    updateCounts(False)  # See comments above updateCounts() for explanation.
+def showQuestionCallBack() -> None:
+    # showInfo("updateCountsForAllDecks(False), currDID = %d" % (currDID if currDID else 0))
+    updateCountsForAllDecks(False)  # see comments at updateCountsForAllDecks()
     updatePB()
 
 


### PR DESCRIPTION
Hi glutanimate,

Here is a quick fix of Progress Bar for latest Anki, related to #146. 

It seems that the related APIs were changed swiftly in Anki 2.1.28, where `deckDueList()` was [removed](https://github.com/ankitects/anki/commit/769bf04f753f6d415501d9230a200955fb5881a5) and `deckDueTree()` was also soon [deprecated](https://github.com/ankitects/anki/commit/24dd116f91839c7987ffff0c6d6100d87b331edb), and replaced by newly introduced `deck_due_tree()`. For compatibility I added a version check to decide whether to use `deck_due_tree()` or the old `deckDueList()`. It seems to work on my Anki 2.1.30, but I haven't tested it on older Anki. Maybe you want to make sure of that.

Also I found a long-living bug of deleting list item during iteration, which might be related to #98. Those deletions are actually unnecessary and is removed now.