### PR TITLE
DONT MERGE WITHOUT READING : fix browser_create_duplicate.py not working in recent anki

### DIFF
--- a/src/browser_create_duplicate/browser_create_duplicate.py
+++ b/src/browser_create_duplicate/browser_create_duplicate.py
@@ -76,8 +76,8 @@ def createDuplicate(self):
         note_copy.fields = note.fields
 
         # Refresh note and add to database
-        note_copy.flush()
         mw.col.addNote(note_copy)
+        note_copy.flush()
         
     # Reset collection and main window
     self.model.endReset()


### PR DESCRIPTION
I am on anki 2.1.33 on Ubuntu 18.04 and apparently swapping those 2 lines fixed this addon not working for me. I have NO idea what it does so don't merge it automatically.

Thanks you for your work <3