### PR TITLE
Stop using legacy function fmtTimeSpan

### DIFF
--- a/src/overview_deck_tooltip/overview_deck_tooltip.py
+++ b/src/overview_deck_tooltip/overview_deck_tooltip.py
@@ -18,7 +18,7 @@ License: GNU AGPLv3 or later <https://www.gnu.org/licenses/agpl.html>
 from aqt.qt import *
 from anki.hooks import wrap
 from anki.lang import _, ngettext
-from anki.utils import ids2str, fmtTimeSpan
+from anki.utils import ids2str
 from aqt import mw
 from aqt.deckbrowser import DeckBrowser
 
@@ -171,7 +171,7 @@ from revlog where id > ? """ + lim, (self.col.sched.dayCutoff - 86400) * 1000)
 
         msgp1 = ngettext("<!--studied-->%d card", "<!--studied-->%d cards", cards) % cards
         b += _("Studied %(a)s in %(b)s today.") % dict(
-            a=bold(msgp1), b=bold(fmtTimeSpan(thetime, unit=1)))
+            a=bold(msgp1), b=bold(mw.col.format_timespan(thetime)))
         # again/pass count
         b += "<br>" + _("Again count: %s") % bold(failed)
         if cards:

--- a/src/reviewer_card_stats/reviewer_card_stats.py
+++ b/src/reviewer_card_stats/reviewer_card_stats.py
@@ -25,7 +25,6 @@ import aqt.stats
 import time
 import datetime
 from anki.lang import _
-from anki.utils import fmtTimeSpan
 from anki.stats import CardStats
 
 
@@ -125,7 +124,7 @@ class StatsSidebar(object):
             if ivl == 0:
                 ivl = _("0d")
             elif ivl > 0:
-                ivl = fmtTimeSpan(ivl * 86400, short=True)
+                ivl = mw.col.format_timespan(ivl * 86400)
             else:
                 ivl = cs.time(-ivl)
 

--- a/src/stats_true_retention_extended/stats_true_retention_extended.py
+++ b/src/stats_true_retention_extended/stats_true_retention_extended.py
@@ -21,7 +21,7 @@ MATURE_IVL = 21 # mature card interval in days
 
 import anki.stats
 
-from anki.utils import fmtTimeSpan
+from aqt import mw
 from anki.lang import _, ngettext
 from anki import version as anki_version
 
@@ -143,7 +143,7 @@ from revlog where id > ? """+lim, (self.col.sched.dayCutoff-86400)*1000)
             return "<b>"+str(s)+"</b>"
     msgp1 = ngettext("<!--studied-->%d card", "<!--studied-->%d cards", cards) % cards
     b += _("Studied %(a)s in %(b)s today.") % dict(
-        a=bold(msgp1), b=bold(fmtTimeSpan(thetime, unit=1)))
+        a=bold(msgp1), b=bold(mw.col.format_timespan(thetime)))
     # again/pass count
     b += "<br>" + _("Again count: %s") % bold(failed)
     if cards:


### PR DESCRIPTION
https://github.com/ankitects/anki/commit/e73157285ec436000091de89a5bd3490611c8651
https://github.com/ankitects/anki/commit/89dde3aeb0c1f94b912b3cb2659ec0d4bffb4a1c

I only tested the changes in the reviewer card stats add-on.
Tested with Anki 2.1.35 (1dd6fed0) on Debian bullseye.