### PR TITLE
Improve compatibility with Anki 2.1.41+

### DIFF
--- a/src/editor_random_list/editor_random_list.py
+++ b/src/editor_random_list/editor_random_list.py
@@ -44,7 +44,7 @@ ul.shuffle{
 def toggleRandUl(self):
     self.web.eval("""
         document.execCommand('insertUnorderedList');
-        var ulElem = window.getSelection().focusNode.parentNode;
+        var ulElem = getCurrentField().getSelection().focusNode.parentNode;
         if (ulElem !== null) {
             var setAttrs = true;
             while (ulElem.toString() !== "[object HTMLUListElement]") {


### PR DESCRIPTION
Fixes RL button to correctly insert `class="shuffle"` into `<ul>` element, thereby allowing shuffling to work correctly in Anki 2.1.41+, which [requires](https://forums.ankiweb.net/t/add-on-porting-notes-for-anki-2-1-41/7390) using `.getSelection()` on a _field_ instead of `window`.

This pull request does NOT fix the yellow background highlight for random lists - i.e., shuffled lists are still NOT highlighted as intended.